### PR TITLE
Added fix to prevent template error

### DIFF
--- a/Controllers/Frontend/QuickPay.php
+++ b/Controllers/Frontend/QuickPay.php
@@ -61,6 +61,9 @@ class Shopware_Controllers_Frontend_QuickPay extends \Shopware_Controllers_Front
      */
     public function callbackAction()
     {
+        // Prevent error from missing template
+        $this->Front()->Plugins()->ViewRenderer()->setNoRender();
+
         //Validate & save order
         $responseBody = $this->Request()->getRawBody();
         $response = json_decode($responseBody);


### PR DESCRIPTION
When the callback hook is called shopware tries to render the page
using the default template named 'frontend/quick_pay/callback.tpl'.
As this template does not exist an error will show up in the backend.
To prevent this the default renderer is disabled.