### PR TITLE
Fix Composer install directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
   "name": "quickpay/shopware",
-  "type": "shopware-frontend-plugin",
+  "type": "shopware-plugin",
   "require": {
     "composer/installers": "~1.0"
+  },
+  "extra": {
+    "installer-name": "QuickPayPayment"
   }
 }


### PR DESCRIPTION
When installing the plugin with Composer, all files end up in:

`Plugin/Local/Frontend/QuickPay_Shopware`

Shopware is not able to detect the new plugin though because the
directory doesn't match the plugin name (`QuickPayPayment`).
Fixing this by defining a custom install directory using the
`installer-name` field in `composer.json`.

Also, according to the installation page, the plugin files should be
moved to `custom/plugins` instead of `Plugin/Local/Frontend/`. See:

https://learn.quickpay.net/helpdesk/en/articles/integrations/shopware/

Not a technical problem but I guess it makes sense to keep this consistent.
Doing this by changing the package type to `shopware-plugin` in `composer.json`.